### PR TITLE
fix: reduce hero top gap, allow admin users to access user dashboard pages

### DIFF
--- a/components/EnhancedHero.tsx
+++ b/components/EnhancedHero.tsx
@@ -31,8 +31,8 @@ export default function EnhancedHero() {
       </div>
 
       {/* Main Content */}
-      <div className="relative isolate px-6 pt-14 lg:px-8">
-        <div className="mx-auto max-w-5xl py-32 sm:py-48 lg:py-56 text-center">
+      <div className="relative isolate px-6 pt-6 lg:px-8">
+        <div className="mx-auto max-w-5xl py-16 sm:py-24 lg:py-28 text-center">
           <motion.div
             className="mx-auto"
             initial={{ opacity: 0, y: 30 }}

--- a/components/auth/WithAuth.tsx
+++ b/components/auth/WithAuth.tsx
@@ -27,8 +27,8 @@ export function WithAuth<P extends object>(WrappedComponent: React.ComponentType
           router.replace(role === 'admin' ? '/admin/dashboard' : '/dashboard');
         } else if (isAdminPath && role !== 'admin') {
           router.replace(role === 'agent' ? '/agent/dashboard' : '/dashboard');
-        } else if (!isAgentPath && !isAdminPath && role !== 'user') {
-          router.replace(role === 'admin' ? '/admin/dashboard' : '/agent/dashboard');
+        } else if (!isAgentPath && !isAdminPath && role === 'agent') {
+          router.replace('/dashboard/agent');
         } else {
           setIsChecking(false);
         }


### PR DESCRIPTION
## Summary

- **Hero padding**: Removed excessive top gap — `pt-14 → pt-6` and `py-32 sm:py-48 lg:py-56 → py-16 sm:py-24 lg:py-28`. Content now sits closer to the navbar without excess dead space.
- **Post New Ad redirect fix**: `WithAuth` was redirecting any non-`user` role (including admins) away from `/dashboard/*` pages to `/admin/dashboard`. Changed the rule so only `agent`-role users are redirected to their own dashboard. Admin users can now access `/dashboard/new-ad` and all other user-facing dashboard pages directly.

## Test plan

- [ ] Landing page hero — text starts closer to the top, no large gap
- [ ] Logged in as admin: click "Post Your Ad — Free" → lands on `/dashboard/new-ad` form
- [ ] Logged in as admin: click "Post New Ad" inside dashboard → lands on form
- [ ] Logged in as agent: visiting `/dashboard/new-ad` → correctly redirected to `/dashboard/agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)