### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { Toaster } from 'react-hot-toast';
 import CookieConsent from "@/components/CookieConsent";
 import Providers from './providers'
 import { Inter } from 'next/font/google';
+import Script from 'next/script';
 
 if (process.env.NODE_ENV === 'development') {
   initCronJobs();
@@ -94,6 +95,18 @@ export default async function RootLayout({
         <script src="https://js.paystack.co/v2/inline.js"></script>
       </head>
       <body className={inter.className}>
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-05GBS0SVDZ"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-05GBS0SVDZ');
+          `}
+        </Script>
         <Providers>
           <SessionWrapper session={initialSession}>
             {children}


### PR DESCRIPTION
Adds Google Analytics 4 (GA4) tracking to the site using the `next/script` component with `afterInteractive` strategy — so it loads after the page is interactive and doesn't block rendering.

Tracking ID: `G-05GBS0SVDZ`

After merging and deploying, visit your site and then check **analytics.google.com** — you should see yourself appear in the **Realtime** report within a minute.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6YCSiZtBd7tqPmfGSXvVz)_