### PR TITLE
feat: fix admin sidebar tabs, welcome email, broadcast email tab

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useSession } from "@/components/SessionWrapper";
 import AdminLayout from "@/components/AdminDashboard/Layout";
 import AdminDashboard from "@/components/AdminDashboard/Dashboard";
@@ -10,8 +10,6 @@ import { Loader2 } from "lucide-react";
 export default function AdminDashboardPage() {
   const { session } = useSession();
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const tab = searchParams.get('tab') || 'dashboard';
 
   useEffect(() => {
     if (session === null) {
@@ -35,7 +33,7 @@ export default function AdminDashboardPage() {
 
   return (
     <AdminLayout>
-      <AdminDashboard defaultTab={tab} />
+      <AdminDashboard />
     </AdminLayout>
   );
 }

--- a/app/api/admin/broadcast-email/route.ts
+++ b/app/api/admin/broadcast-email/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { quickSend } from '@/lib/email';
+import { cookies } from 'next/headers';
+import jwt from 'jsonwebtoken';
+
+export async function POST(req: NextRequest) {
+  try {
+    // Verify admin session
+    const cookieStore = await cookies();
+    const sessionToken = cookieStore.get('next-auth.session-token')?.value;
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const session = jwt.verify(sessionToken, process.env.NEXTAUTH_SECRET!) as { role?: string };
+    if (session.role !== 'admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const { subject, content } = await req.json();
+
+    if (!subject?.trim() || !content?.trim()) {
+      return NextResponse.json({ error: 'Subject and content are required' }, { status: 400 });
+    }
+
+    // Fetch all verified users
+    const users = await prisma.user.findMany({
+      where: { verified: true },
+      select: { id: true, name: true, email: true },
+    });
+
+    if (users.length === 0) {
+      return NextResponse.json({ error: 'No verified users found' }, { status: 404 });
+    }
+
+    let sent = 0;
+    let failed = 0;
+
+    // Send in batches of 10 to avoid rate limits
+    const BATCH_SIZE = 10;
+    for (let i = 0; i < users.length; i += BATCH_SIZE) {
+      const batch = users.slice(i, i + BATCH_SIZE);
+      await Promise.allSettled(
+        batch.map(async (user) => {
+          const firstName = user.name.split(' ')[0];
+          const result = await quickSend.broadcast(user.email, firstName, subject, content);
+          if (result.success) {
+            sent++;
+          } else {
+            failed++;
+            console.error(`Broadcast failed for ${user.email}:`, result.error);
+          }
+        })
+      );
+      // Small delay between batches
+      if (i + BATCH_SIZE < users.length) {
+        await new Promise((r) => setTimeout(r, 200));
+      }
+    }
+
+    return NextResponse.json({
+      message: 'Broadcast complete',
+      total: users.length,
+      sent,
+      failed,
+    });
+  } catch (error) {
+    console.error('Broadcast email error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -105,21 +105,26 @@ export async function POST(req: NextRequest) {
     // Generate a verification token
     const verificationToken = jwt.sign({ userId: user.id }, process.env.NEXTAUTH_SECRET!, { expiresIn: '1d' });
 
+    const firstName = sanitizedName.split(' ')[0];
+
     // Send verification email
     const verificationUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/api/verify-email?token=${verificationToken}`;
     try {
-      const result = await quickSend.verification(sanitizedEmail, sanitizedName, verificationUrl);
+      const result = await quickSend.verification(sanitizedEmail, firstName, verificationUrl);
 
       if (!result.success) {
         console.error('Verification email failed:', result.error);
-        // Continue with user creation even if email fails
       } else {
         console.log('Verification email sent successfully:', result.messageId);
       }
     } catch (error: any) {
       console.error('Email sending failed:', error);
-      // Continue with user creation even if email fails
     }
+
+    // Send welcome email (non-blocking)
+    quickSend.welcome(sanitizedEmail, firstName).catch((err) =>
+      console.error('Welcome email failed:', err)
+    );
 
     return jsonResponse(201, { message: 'User created successfully', user: { id: user.id, name: user.name, email: user.email } });
   } catch (error: any) {

--- a/components/AdminDashboard/BroadcastEmail.tsx
+++ b/components/AdminDashboard/BroadcastEmail.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import { Send, Users, AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import toast from "react-hot-toast";
+
+interface BroadcastResult {
+  total: number;
+  sent: number;
+  failed: number;
+}
+
+export default function BroadcastEmail() {
+  const [subject, setSubject] = useState("");
+  const [content, setContent] = useState("");
+  const [sending, setSending] = useState(false);
+  const [result, setResult] = useState<BroadcastResult | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleSend = async () => {
+    setSending(true);
+    setShowConfirm(false);
+    setResult(null);
+
+    try {
+      const res = await fetch("/api/admin/broadcast-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ subject, content }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error || "Broadcast failed");
+        return;
+      }
+
+      setResult(data);
+      toast.success(`Broadcast sent to ${data.sent} users`);
+    } catch (err) {
+      toast.error("An error occurred. Please try again.");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const isReady = subject.trim().length > 0 && content.trim().length > 0;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-bold text-gray-900">Broadcast Email</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Send a message to all verified users on the platform. Each email is personalised with the recipient&apos;s first name.
+        </p>
+      </div>
+
+      {/* Result banner */}
+      {result && (
+        <div className="flex items-start gap-3 bg-green-50 border border-green-200 rounded-lg p-4">
+          <CheckCircle2 className="w-5 h-5 text-green-600 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-semibold text-green-800">Broadcast complete</p>
+            <p className="text-sm text-green-700 mt-1">
+              {result.sent} of {result.total} emails sent successfully.
+              {result.failed > 0 && (
+                <span className="text-red-600 ml-1">{result.failed} failed.</span>
+              )}
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="bg-white rounded-xl border shadow-sm p-6 space-y-5">
+        {/* Subject */}
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1">
+            Email Subject <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="e.g. Important update from AgroMarket NG"
+            className="w-full border border-gray-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
+          />
+        </div>
+
+        {/* Content */}
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1">
+            Message Body <span className="text-red-500">*</span>
+          </label>
+          <p className="text-xs text-gray-400 mb-2">
+            Plain text. Each email will begin with &ldquo;Hi [First Name],&rdquo; automatically.
+          </p>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            rows={10}
+            placeholder={`We're excited to share some great news with you...\n\nYou can now post unlimited ads for free on AgroMarket NG.\n\nVisit us to list your farm produce today.`}
+            className="w-full border border-gray-300 rounded-lg px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent resize-y font-mono"
+          />
+          <p className="text-xs text-gray-400 mt-1 text-right">{content.length} characters</p>
+        </div>
+
+        {/* Preview */}
+        {isReady && (
+          <div>
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Preview</p>
+            <div className="border border-gray-200 rounded-lg p-4 bg-gray-50 text-sm text-gray-700 space-y-2">
+              <p><span className="font-semibold text-gray-500">Subject:</span> {subject}</p>
+              <hr className="border-gray-200" />
+              <p className="text-gray-600">Hi [First Name],</p>
+              <p className="whitespace-pre-wrap text-gray-700">{content}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Warning */}
+        <div className="flex items-start gap-2 text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-3">
+          <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+          <p className="text-xs leading-relaxed">
+            This will send an email to <strong>every verified user</strong> on the platform. Double-check your message before sending.
+          </p>
+        </div>
+
+        {/* Actions */}
+        {!showConfirm ? (
+          <Button
+            onClick={() => setShowConfirm(true)}
+            disabled={!isReady || sending}
+            className="bg-green-700 hover:bg-green-800 text-white w-full sm:w-auto"
+          >
+            <Users className="w-4 h-4 mr-2" />
+            Send to All Users
+          </Button>
+        ) : (
+          <div className="flex flex-col sm:flex-row gap-3">
+            <Button
+              onClick={handleSend}
+              disabled={sending}
+              className="bg-green-700 hover:bg-green-800 text-white"
+            >
+              {sending ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Sending…
+                </>
+              ) : (
+                <>
+                  <Send className="w-4 h-4 mr-2" />
+                  Yes, send now
+                </>
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setShowConfirm(false)}
+              disabled={sending}
+            >
+              Cancel
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/AdminDashboard/Dashboard.tsx
+++ b/components/AdminDashboard/Dashboard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { BarChart3, Users, MessageSquare, Clock, Settings, Loader2, LineChart, UserCog, Megaphone } from "lucide-react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { BarChart3, Users, MessageSquare, Clock, Settings, Loader2, LineChart, UserCog, Megaphone, Mail } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ManageAgent from "./ManageAgent";
 import Chat from "./Chat";
@@ -9,6 +10,7 @@ import SettingsTab from "./Settings";
 import SupportAnalytics from "./SupportAnalytics";
 import UserManagement from "./UserManagement";
 import AdsManagement from "./AdsManagement";
+import BroadcastEmail from "./BroadcastEmail";
 import toast from "react-hot-toast";
 
 interface AdminStats {
@@ -19,13 +21,16 @@ interface AdminStats {
   resolutionRate: number;
 }
 
-interface AdminDashboardProps {
-  defaultTab?: string;
-}
-
-export default function AdminDashboard({ defaultTab = "dashboard" }: AdminDashboardProps) {
+export default function AdminDashboard() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const activeTab = searchParams.get("tab") || "dashboard";
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const handleTabChange = (value: string) => {
+    router.push(`/admin/dashboard?tab=${value}`);
+  };
 
   useEffect(() => {
     fetchStats();
@@ -58,8 +63,8 @@ export default function AdminDashboard({ defaultTab = "dashboard" }: AdminDashbo
         <p className="text-gray-500 mt-1">Overview of your support operations</p>
       </div>
 
-      <Tabs defaultValue={defaultTab} className="w-full">
-        <TabsList className="grid w-full grid-cols-7 mb-6">
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
+        <TabsList className="grid w-full grid-cols-8 mb-6">
           <TabsTrigger value="dashboard" className="text-xs sm:text-sm">
             <BarChart3 className="w-4 h-4 mr-1 sm:mr-2" />
             <span className="hidden sm:inline">Dashboard</span>
@@ -89,6 +94,11 @@ export default function AdminDashboard({ defaultTab = "dashboard" }: AdminDashbo
             <LineChart className="w-4 h-4 mr-1 sm:mr-2" />
             <span className="hidden sm:inline">Analytics</span>
             <span className="sm:hidden">Stats</span>
+          </TabsTrigger>
+          <TabsTrigger value="broadcast" className="text-xs sm:text-sm">
+            <Mail className="w-4 h-4 mr-1 sm:mr-2" />
+            <span className="hidden sm:inline">Broadcast</span>
+            <span className="sm:hidden">Mail</span>
           </TabsTrigger>
           <TabsTrigger value="settings" className="text-xs sm:text-sm">
             <Settings className="w-4 h-4 mr-1 sm:mr-2" />
@@ -237,6 +247,10 @@ export default function AdminDashboard({ defaultTab = "dashboard" }: AdminDashbo
 
         <TabsContent value="analytics">
           <SupportAnalytics />
+        </TabsContent>
+
+        <TabsContent value="broadcast">
+          <BroadcastEmail />
         </TabsContent>
 
         <TabsContent value="settings">

--- a/components/AdminDashboard/Layout.tsx
+++ b/components/AdminDashboard/Layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { useSession } from "@/components/SessionWrapper";
@@ -16,6 +16,7 @@ import {
   X,
   LineChart,
   Megaphone,
+  Mail,
 } from "lucide-react";
 
 
@@ -23,47 +24,28 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   const [isOpen, setIsOpen] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const router = useRouter();
   const { setSession } = useSession();
 
-  // Custom navigation items with direct links to dashboard tabs
+  const currentTab = searchParams.get("tab") || "dashboard";
+
   const customNavItems = [
-    {
-      title: "Dashboard",
-      href: "/admin/dashboard",
-      icon: LayoutDashboard,
-    },
-    {
-      title: "Users",
-      href: "/admin/dashboard?tab=users",
-      icon: UserCog,
-    },
-    {
-      title: "Ads",
-      href: "/admin/dashboard?tab=ads",
-      icon: Megaphone,
-    },
-    {
-      title: "Manage Agents",
-      href: "/admin/agents",
-      icon: Users,
-    },
-    {
-      title: "Chats",
-      href: "/admin/dashboard?tab=chat",
-      icon: MessageSquare,
-    },
-    {
-      title: "Analytics",
-      href: "/admin/dashboard?tab=analytics",
-      icon: LineChart,
-    },
-    {
-      title: "Settings",
-      href: "/admin/dashboard?tab=settings",
-      icon: Settings,
-    },
+    { title: "Dashboard", tab: "dashboard", href: "/admin/dashboard", icon: LayoutDashboard },
+    { title: "Users", tab: "users", href: "/admin/dashboard?tab=users", icon: UserCog },
+    { title: "Ads", tab: "ads", href: "/admin/dashboard?tab=ads", icon: Megaphone },
+    { title: "Manage Agents", tab: null, href: "/admin/agents", icon: Users },
+    { title: "Chats", tab: "chat", href: "/admin/dashboard?tab=chat", icon: MessageSquare },
+    { title: "Analytics", tab: "analytics", href: "/admin/dashboard?tab=analytics", icon: LineChart },
+    { title: "Broadcast", tab: "broadcast", href: "/admin/dashboard?tab=broadcast", icon: Mail },
+    { title: "Settings", tab: "settings", href: "/admin/dashboard?tab=settings", icon: Settings },
   ];
+
+  const isActive = (item: typeof customNavItems[0]) => {
+    if (item.href === "/admin/agents") return pathname === "/admin/agents";
+    if (item.tab === "dashboard") return pathname === "/admin/dashboard" && currentTab === "dashboard";
+    return pathname === "/admin/dashboard" && currentTab === item.tab;
+  };
 
   const handleLogout = async () => {
     try {
@@ -125,11 +107,11 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
               <Link
                 key={item.href}
                 href={item.href}
+                onClick={() => setIsOpen(false)}
                 className={cn(
                   "flex items-center px-4 py-3 text-sm rounded-lg transition-colors",
-                  pathname === item.href ||
-                    (pathname === "/admin/dashboard" && item.href.includes(`?tab=${new URLSearchParams(pathname.includes("?") ? pathname.split("?")[1] : "").get("tab") || "dashboard"}`))
-                    ? "bg-green-50 text-green-600"
+                  isActive(item)
+                    ? "bg-green-50 text-green-600 font-medium"
                     : "text-gray-600 hover:bg-gray-50"
                 )}
               >

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -135,6 +135,17 @@ export const quickSend = {
       resetPasswordUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/reset-password`,
       year: new Date().getFullYear()
     }, { priority: 'high' });
+  },
+
+  // Admin broadcast to a single user
+  broadcast: async (to: string, name: string, subject: string, content: string) => {
+    return emailService.sendTemplatedEmail('broadcast', to, {
+      name,
+      subject,
+      content,
+      baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+      year: new Date().getFullYear()
+    });
   }
 };
 

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -143,66 +143,147 @@ export const emailTemplates: Record<string, EmailTemplateData> = {
     description: 'Security notification for failed login attempts'
   },
   welcome: {
-    subject: 'Welcome to AgroMarket, {{name}}!',
+    subject: 'Welcome to AgroMarket NG, {{name}}! Here\'s how to get started',
     html: `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e0e0e0; border-radius: 8px; background-color: #ffffff;">
-        <div style="text-align: center; margin-bottom: 30px;">
-          <h1 style="color: #166534; margin: 0; font-size: 28px;">AgroMarket</h1>
-          <p style="color: #16a34a; font-size: 16px; margin: 5px 0 0 0;">Connecting Agricultural Communities</p>
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #ffffff;">
+
+        <!-- Header -->
+        <div style="background-color: #166534; padding: 32px 24px; text-align: center; border-radius: 8px 8px 0 0;">
+          <h1 style="color: #ffffff; margin: 0; font-size: 28px; letter-spacing: 1px;">AgroMarket NG</h1>
+          <p style="color: #86efac; font-size: 14px; margin: 6px 0 0 0;">Nigeria's Agricultural Marketplace</p>
         </div>
 
-        <h2 style="color: #166534; text-align: center; margin-bottom: 20px;">Welcome to Our Community!</h2>
+        <!-- Body -->
+        <div style="padding: 32px 24px; border: 1px solid #e0e0e0; border-top: none;">
 
-        <p style="font-size: 16px; line-height: 1.6; color: #333;">Hello {{name}},</p>
+          <p style="font-size: 17px; line-height: 1.6; color: #111827; margin-top: 0;">Hi {{name}},</p>
 
-        <p style="font-size: 16px; line-height: 1.6; color: #333;">
-          Thank you for joining AgroMarket! We're excited to have you as part of our growing agricultural community.
-        </p>
+          <p style="font-size: 15px; line-height: 1.7; color: #374151;">
+            Welcome to <strong>AgroMarket NG</strong> — Nigeria's trusted platform for buying and selling agricultural products. Whether you're a farmer, dealer, or buyer, you're now part of a community connecting thousands of people across the country.
+          </p>
 
-        <div style="background-color: #f0fdf4; padding: 20px; border-radius: 8px; margin: 20px 0;">
-          <h3 style="color: #166534; margin-top: 0;">What's Next?</h3>
-          <ul style="color: #333; line-height: 1.6;">
-            <li>Complete your profile to connect with other farmers</li>
-            <li>Browse our marketplace for agricultural products</li>
-            <li>Join discussions in our community forums</li>
-            <li>Access expert agricultural advice and resources</li>
-          </ul>
-        </div>
+          <!-- What you can do -->
+          <div style="background-color: #f0fdf4; border-radius: 8px; padding: 20px 24px; margin: 24px 0;">
+            <h2 style="color: #166534; font-size: 16px; margin: 0 0 14px 0;">🌾 What you can do on AgroMarket NG</h2>
+            <table style="width: 100%; border-collapse: collapse;">
+              <tr>
+                <td style="padding: 6px 0; color: #166534; font-size: 18px; width: 28px; vertical-align: top;">✅</td>
+                <td style="padding: 6px 0; color: #374151; font-size: 14px; line-height: 1.5;"><strong>Post unlimited ads for free</strong> — list your farm produce, livestock, equipment, or agro inputs at no cost.</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #166534; font-size: 18px; width: 28px; vertical-align: top;">✅</td>
+                <td style="padding: 6px 0; color: #374151; font-size: 14px; line-height: 1.5;"><strong>Reach buyers across Nigeria</strong> — your listings are visible to buyers in Lagos, Abuja, Kano, Port Harcourt, and everywhere in between.</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #166534; font-size: 18px; width: 28px; vertical-align: top;">✅</td>
+                <td style="padding: 6px 0; color: #374151; font-size: 14px; line-height: 1.5;"><strong>Message sellers directly</strong> — no middleman. Contact any seller through our built-in messaging to negotiate and close deals.</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #166534; font-size: 18px; width: 28px; vertical-align: top;">✅</td>
+                <td style="padding: 6px 0; color: #374151; font-size: 14px; line-height: 1.5;"><strong>Boost your ads</strong> — get featured placement to appear at the top of search results and reach more buyers faster.</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #166534; font-size: 18px; width: 28px; vertical-align: top;">✅</td>
+                <td style="padding: 6px 0; color: #374151; font-size: 14px; line-height: 1.5;"><strong>Read expert farming guides</strong> — our blog covers crop management, pricing strategies, loans, and more.</td>
+              </tr>
+            </table>
+          </div>
 
-        <div style="text-align: center; margin: 30px 0;">
-          <a href="{{baseUrl}}/dashboard" style="background-color: #166534; color: white; padding: 14px 28px; text-decoration: none; border-radius: 6px; font-weight: bold; display: inline-block; font-size: 16px;">
-            Get Started
-          </a>
-        </div>
+          <!-- Guidelines -->
+          <div style="background-color: #fffbeb; border-left: 4px solid #f59e0b; border-radius: 0 8px 8px 0; padding: 16px 20px; margin: 24px 0;">
+            <h2 style="color: #92400e; font-size: 15px; margin: 0 0 10px 0;">📋 Platform Guidelines</h2>
+            <ul style="color: #78350f; font-size: 14px; line-height: 1.7; margin: 0; padding-left: 18px;">
+              <li>Only post genuine agricultural products — no fake or misleading listings.</li>
+              <li>Use accurate descriptions, photos, and prices. Buyers rely on this to make decisions.</li>
+              <li>Respond promptly to messages from buyers. Fast responses build your reputation.</li>
+              <li>Do not share personal financial details (bank PIN, passwords) through the platform.</li>
+              <li>Treat all buyers and sellers with respect. We have zero tolerance for scams or harassment.</li>
+            </ul>
+          </div>
 
-        <p style="font-size: 14px; color: #666; text-align: center; margin-top: 30px;">
-          Need help? Contact our support team at <a href="mailto:support@agromarket.com" style="color: #166534;">support@agromarket.com</a>
-        </p>
+          <!-- CTA -->
+          <div style="text-align: center; margin: 32px 0 24px 0;">
+            <a href="{{baseUrl}}/dashboard/new-ad" style="background-color: #166534; color: #ffffff; padding: 14px 32px; text-decoration: none; border-radius: 6px; font-weight: bold; font-size: 15px; display: inline-block;">
+              Post Your First Ad →
+            </a>
+          </div>
 
-        <div style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #e0e0e0; text-align: center; color: #666; font-size: 12px;">
-          <p>© {{year}} AgroMarket. All rights reserved.</p>
-          <p>You're receiving this email because you created an account with AgroMarket.</p>
+          <p style="font-size: 14px; line-height: 1.7; color: #6b7280; text-align: center;">
+            Or <a href="{{baseUrl}}/products" style="color: #166534; text-decoration: none; font-weight: 600;">browse current listings</a> to find what you're looking for.
+          </p>
+
+          <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 28px 0;" />
+
+          <p style="font-size: 13px; color: #9ca3af; line-height: 1.6; text-align: center; margin: 0;">
+            Need help? Reply to this email or visit our <a href="{{baseUrl}}/dashboard/support" style="color: #166534;">support centre</a>.<br/>
+            © {{year}} AgroMarket NG. All rights reserved.
+          </p>
         </div>
       </div>
     `,
     text: `
-      Welcome to AgroMarket, {{name}}!
+Hi {{name}},
 
-      Thank you for joining our agricultural community. We're excited to have you aboard!
+Welcome to AgroMarket NG — Nigeria's trusted platform for buying and selling agricultural products.
 
-      What's Next:
-      - Complete your profile to connect with other farmers
-      - Browse our marketplace for agricultural products
-      - Join discussions in our community forums
-      - Access expert agricultural advice and resources
+WHAT YOU CAN DO:
+- Post unlimited ads for free
+- Reach buyers across Nigeria
+- Message sellers directly — no middleman
+- Boost your ads for more visibility
+- Read expert farming guides on our blog
 
-      Get started: {{baseUrl}}/dashboard
+PLATFORM GUIDELINES:
+- Only post genuine agricultural products
+- Use accurate descriptions, photos, and prices
+- Respond promptly to messages
+- Never share financial details through the platform
+- Treat everyone with respect
 
-      Need help? Contact us at support@agromarket.com
+Post your first ad: {{baseUrl}}/dashboard/new-ad
+Browse listings: {{baseUrl}}/products
 
-      © {{year}} AgroMarket. All rights reserved.
+Need help? Contact support at {{baseUrl}}/dashboard/support
+
+© {{year}} AgroMarket NG. All rights reserved.
     `,
-    description: 'Welcome email for new users'
+    description: 'Comprehensive welcome email for new users'
+  },
+
+  broadcast: {
+    subject: '{{subject}}',
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #ffffff;">
+        <div style="background-color: #166534; padding: 28px 24px; text-align: center; border-radius: 8px 8px 0 0;">
+          <h1 style="color: #ffffff; margin: 0; font-size: 24px;">AgroMarket NG</h1>
+          <p style="color: #86efac; font-size: 13px; margin: 4px 0 0 0;">Nigeria's Agricultural Marketplace</p>
+        </div>
+        <div style="padding: 32px 24px; border: 1px solid #e0e0e0; border-top: none;">
+          <p style="font-size: 16px; color: #111827; margin-top: 0;">Hi {{name}},</p>
+          <div style="font-size: 15px; line-height: 1.8; color: #374151;">{{content}}</div>
+          <div style="text-align: center; margin: 32px 0;">
+            <a href="{{baseUrl}}/products" style="background-color: #166534; color: #ffffff; padding: 13px 28px; text-decoration: none; border-radius: 6px; font-weight: bold; font-size: 14px; display: inline-block;">
+              Visit AgroMarket NG
+            </a>
+          </div>
+          <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />
+          <p style="font-size: 12px; color: #9ca3af; text-align: center; margin: 0;">
+            © {{year}} AgroMarket NG. All rights reserved.<br/>
+            You're receiving this because you have an account on <a href="{{baseUrl}}" style="color: #166534;">agromarketng.com</a>.
+          </p>
+        </div>
+      </div>
+    `,
+    text: `
+Hi {{name}},
+
+{{content}}
+
+Visit AgroMarket NG: {{baseUrl}}/products
+
+© {{year}} AgroMarket NG. All rights reserved.
+    `,
+    description: 'Admin broadcast/newsletter to all users'
   },
 
   verification: {

--- a/lib/email/types.ts
+++ b/lib/email/types.ts
@@ -5,6 +5,7 @@ export type EmailTemplate =
   | 'newsletter-confirmation'
   | 'support-reply'
   | 'agent-welcome'
+  | 'broadcast'
   | 'chat-notification'
   | 'agent-assigned'
   | 'ticket-created'


### PR DESCRIPTION
## Summary

**1. Fix admin sidebar tabs**
- Root cause: `<Tabs defaultValue={...}>` only sets state on first render — sidebar link clicks changed the URL but the tab content never switched.
- Fix: `Dashboard.tsx` now uses controlled `value={activeTab}` driven by `useSearchParams()`, and `onValueChange` pushes the new tab to the router. Both sidebar links and top tab clicks now stay in sync.
- `Layout.tsx` active-state highlighting replaced with a clean `isActive()` helper using `useSearchParams()`.

**2. Comprehensive welcome email**
- Replaced the basic welcome template with a full onboarding email covering: what the platform does, key features (unlimited free ads, messaging, boost, blog), and platform guidelines (no fake listings, respond promptly, no sharing financial details).
- Email is sent non-blocking after signup so it never delays account creation.
- User is addressed by their first name (extracted from full name).

**3. Broadcast email tab**
- New **Broadcast** tab in the admin dashboard sidebar and top tab bar.
- Admin can write a subject and message body, preview how it will look, then send to all verified users with a confirmation step.
- Each email is personalised with the recipient's first name.
- Emails are sent in batches of 10 to respect rate limits.
- Result summary shows total sent / failed count.
- Backed by `POST /api/admin/broadcast-email` — admin-only, verified via session JWT.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6YCSiZtBd7tqPmfGSXvVz)_